### PR TITLE
Move the led properties to the new location that is used in cm

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -45,13 +45,6 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 
-    <!-- Does the notification LED support multiple colors?
-         Used to decide if the user can change the colors -->
-    <bool name="config_multiColorNotificationLed">true</bool>
-
-    <!-- Can we change the battery color? -->
-    <bool name="config_multiColorBatteryLed">true</bool>
-
     <!-- List of regexpressions describing the interface (if any) that represent tetherable
          USB interfaces.  If the device doesn't want to support tething over USB this should
          be empty.  An example would be "usb.*" -->

--- a/overlay/vendor/cmsdk/cm/res/res/values/config.xml
+++ b/overlay/vendor/cmsdk/cm/res/res/values/config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- All the capabilities of the LEDs on this device, stored as a bit field.
+         This integer should equal the sum of the corresponding value for each
+         of the following capabilities present:
+
+         LIGHTS_RGB_NOTIFICATION_LED = 1
+         LIGHTS_RGB_BATTERY_LED = 2
+         LIGHTS_MULTIPLE_NOTIFICATION_LED = 4
+         LIGHTS_PULSATING_LED = 8
+         LIGHTS_SEGMENTED_BATTERY_LED = 16
+         LIGHTS_ADJUSTABLE_NOTIFICATION_LED_BRIGHTNESS = 32
+
+         For example, a device support pulsating, RGB notification and
+         battery LEDs would set this config to 11. -->
+    <integer name="config_deviceLightCapabilities">3</integer>
+</resources>


### PR DESCRIPTION
CM 14.1 now uses a new format to track the LED capabilities of a device.
Removed from frameworks/base in 04b8389aec4f5248b72b51c1521056b12abfcbf2
Added to vendor/cm with 610916b378517bf841783b191f9fe94643b19ac1
Without this change the build breaks.